### PR TITLE
修复Canvas.setMaxFps实际设置帧率是期望值10倍的问题

### DIFF
--- a/autojs/src/main/java/com/stardust/autojs/core/graphics/ScriptCanvasView.kt
+++ b/autojs/src/main/java/com/stardust/autojs/core/graphics/ScriptCanvasView.kt
@@ -39,7 +39,7 @@ class ScriptCanvasView(context: Context, private val mScriptRuntime: ScriptRunti
         mTimePerDraw = if (maxFps <= 0) {
             0
         } else {
-            (100 / maxFps).toLong()
+            (1000 / maxFps).toLong()
         }
     }
 


### PR DESCRIPTION
(少了个0)

兼容旧版本: https://github.com/happyme531/clxTools/commit/b11854d3510a9273bc94693b08713bc8b11f2525